### PR TITLE
Fix Github repository URL typo in setup instructions

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -57,7 +57,7 @@ cd Solitary
 Then add `Popespacious/Solitary` as the upstream remote:
 
 ```
-git remote add upstream https://github.com/Popespacious/Solitary.git
+git remote add upstream https://github.com/PopeSpaceous/Solitary.git
 ```  
 ### Step 5: Create a Branch  
 It's common practice to create a new branch for each new feature or bugfix you are working on. Let's go ahead and create one!

--- a/Setup.md
+++ b/Setup.md
@@ -54,7 +54,7 @@ If you haven't already, start by changing your directory to the rebus repository
 cd Solitary
 ```
 
-Then add `Popespacious/Solitary` as the upstream remote:
+Then add `PopeSpacious/Solitary` as the upstream remote:
 
 ```
 git remote add upstream https://github.com/PopeSpaceous/Solitary.git


### PR DESCRIPTION
I was following the instructions and I tried running `git fetch upstream master` and I got this error:

```bash
remote: Repository not found.
fatal: repository 'https://github.com/Popespacious/Solitary.git/' not found
```

Just a typo. Should be `https://github.com/PopeSpaceous/Solitary.git`