### PR TITLE
Fix tangram snap when source and target tangram matches

### DIFF
--- a/Assets/Scripts/PuzzleScripts/Tangrams/Tans.cs
+++ b/Assets/Scripts/PuzzleScripts/Tangrams/Tans.cs
@@ -90,7 +90,7 @@ public class Tans : MonoBehaviour {
 				//if they're the same type of Tan
 				if (this.type == inTan.type) {
 					//move the current tan to the position of the Puzzle Tan. 
-					this.transform.position = new Vector3 (inTan.transform.position.x, this.transform.position.y, 1.0f);
+					this.transform.position = new Vector3 (inTan.transform.position.x, inTan.transform.position.y, 1.0f);
 					//set x & y to true
 					xCheck = true;	
 					yCheck = true;


### PR DESCRIPTION
While looking at Issue #114 I stumbled upon a bug that was causing the moveable tangram not to snap correctly when it matches the target outline tangram.

**Platform:** Windows 8.1 Embedded
**Unity Version:**  2017.3.0

![fix-snap-matching-outline-tangram](https://user-images.githubusercontent.com/5477929/48307322-5d2ce800-e518-11e8-8115-3b74598a1d9f.png)

Looks much nicer.

I'll look into adding the snap function.